### PR TITLE
Update crux.sh

### DIFF
--- a/crux_db/crux.sh
+++ b/crux_db/crux.sh
@@ -380,8 +380,10 @@ do
 done
 
 # for all of of derepliated blast hits, combine and depreplicate by length
-python ${DB}/scripts/combine_and_dereplicate_fasta.py -o ${ODIR}/${NAME}_db_unfiltered/${NAME}_fasta_and_taxonomy/${NAME}_.fasta -a ${ODIR}/${NAME}_db_unfiltered/${NAME}_fasta_and_taxonomy/*_blast_out.fasta
+# use -d to avoid using the wildcard which has a limit on the argument list
+python ${DB}/scripts/combine_and_dereplicate_fasta.py -o ${ODIR}/${NAME}_db_unfiltered/${NAME}_.fasta -d ${ODIR}/${NAME}_db_unfiltered/${NAME}_fasta_and_taxonomy
 rm ${ODIR}/${NAME}_db_unfiltered/${NAME}_fasta_and_taxonomy/*_blast_out.fasta
+mv ${ODIR}/${NAME}_db_unfiltered/${NAME}_.fasta ${ODIR}/${NAME}_db_unfiltered/${NAME}_fasta_and_taxonomy/${NAME}_.fasta
 
 ### add taxonomy using entrez_qiime.py
 echo "...Running ${j} entrez-qiime and cleaning up fasta and taxonomy files"


### PR DESCRIPTION
For some of my CRUX runs there are too many *out.fasta files, and the job fails on combine_and_dereplicate.py. It's better to use the -d option which takes the entire directory as input regardless of how many files it contains.